### PR TITLE
Add migration tables for payment system

### DIFF
--- a/database/migrations/2025_06_17_012357_create_accounts_table.php
+++ b/database/migrations/2025_06_17_012357_create_accounts_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('accounts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users');
+            $table->decimal('balance', 10, 2)->default(0);
+            $table->string('pin', 64);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('accounts');
+    }
+};

--- a/database/migrations/2025_06_17_012359_create_recharges_table.php
+++ b/database/migrations/2025_06_17_012359_create_recharges_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('recharges', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('account_id')->constrained('accounts');
+            $table->decimal('amount', 10, 2);
+            $table->string('bank_name', 100)->nullable();
+            $table->string('reference', 100)->nullable();
+            $table->string('receipt_url', 255)->nullable();
+            $table->enum('status', ['pending', 'approved', 'rejected'])->default('pending');
+            $table->foreignId('approved_by')->nullable()->constrained('users');
+            $table->timestamp('approved_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('recharges');
+    }
+};

--- a/database/migrations/2025_06_17_012401_create_transfers_table.php
+++ b/database/migrations/2025_06_17_012401_create_transfers_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('transfers', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('from_account_id')->constrained('accounts');
+            $table->foreignId('to_account_id')->constrained('accounts');
+            $table->decimal('amount', 10, 2);
+            $table->string('description')->nullable();
+            $table->enum('status', ['pending', 'completed', 'failed'])->default('completed');
+            $table->timestamp('transferred_at')->useCurrent();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('transfers');
+    }
+};

--- a/database/migrations/2025_06_17_012403_create_prepaid_cards_table.php
+++ b/database/migrations/2025_06_17_012403_create_prepaid_cards_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('prepaid_cards', function (Blueprint $table) {
+            $table->id();
+            $table->string('code', 50)->unique();
+            $table->string('pin', 64);
+            $table->decimal('amount', 10, 2);
+            $table->foreignId('business_id')->constrained('users');
+            $table->foreignId('user_id')->nullable()->constrained('users');
+            $table->enum('status', ['inactive', 'active', 'redeemed', 'expired'])->default('inactive');
+            $table->timestamp('activated_at')->nullable();
+            $table->timestamp('redeemed_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('prepaid_cards');
+    }
+};


### PR DESCRIPTION
## Summary
- create accounts, recharges, transfers and prepaid_cards migrations

## Testing
- `composer test`
- `php artisan migrate --pretend`


------
https://chatgpt.com/codex/tasks/task_e_6850c2ee92248329a0b6561e62f85aa6