### PR TITLE
Add marketplace migrations

### DIFF
--- a/database/migrations/2025_06_17_012803_create_products_table.php
+++ b/database/migrations/2025_06_17_012803_create_products_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('products', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('business_id')->constrained('users');
+            $table->string('name', 100);
+            $table->text('description')->nullable();
+            $table->decimal('price', 10, 2);
+            $table->integer('stock')->default(0);
+            $table->enum('status', ['active', 'inactive'])->default('active');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('products');
+    }
+};

--- a/database/migrations/2025_06_17_012805_create_orders_table.php
+++ b/database/migrations/2025_06_17_012805_create_orders_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('orders', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users');
+            $table->foreignId('business_id')->constrained('users');
+            $table->integer('total_items');
+            $table->decimal('total_amount', 10, 2);
+            $table->enum('status', ['pending', 'processing', 'completed', 'cancelled'])
+                ->default('pending');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('orders');
+    }
+};

--- a/database/migrations/2025_06_17_012806_create_order_items_table.php
+++ b/database/migrations/2025_06_17_012806_create_order_items_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('order_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('order_id')->constrained('orders');
+            $table->foreignId('product_id')->constrained('products');
+            $table->integer('quantity');
+            $table->decimal('unit_price', 10, 2);
+            $table->decimal('total_price', 10, 2);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('order_items');
+    }
+};

--- a/database/migrations/2025_06_17_012808_create_deliveries_table.php
+++ b/database/migrations/2025_06_17_012808_create_deliveries_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('deliveries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('order_id')->constrained('orders');
+            $table->foreignId('courier_id')->constrained('users');
+            $table->enum('status', ['pending', 'assigned', 'picked_up', 'delivered', 'cancelled'])
+                ->default('pending');
+            $table->timestamp('delivered_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('deliveries');
+    }
+};


### PR DESCRIPTION
## Summary
- create Products table with business relation
- create Orders table with totals and statuses
- create OrderItems table
- create Deliveries table linked to orders

## Testing
- `./vendor/bin/phpunit --stop-on-failure --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_6850c43acb28832998eb03f5d4e15f78