### PR TITLE
Add delivery tracking columns

### DIFF
--- a/app/Models/Delivery.php
+++ b/app/Models/Delivery.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Delivery extends Model
+{
+    use HasFactory;
+
+    /**
+     * Atributos asignables de forma masiva.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'order_id',
+        'courier_id',
+        'status',
+        'delivered_at',
+        'picked_up_at',
+        'pickup_code',
+        'pickup_verified_at',
+        'delivery_code',
+        'delivery_verified_at',
+        'last_track_id',
+        'canceled_at',
+    ];
+
+    /**
+     * Conversión de atributos a tipos nativos.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'delivered_at'        => 'datetime',
+            'picked_up_at'        => 'datetime',
+            'pickup_verified_at'  => 'datetime',
+            'delivery_verified_at'=> 'datetime',
+            'canceled_at'         => 'datetime',
+        ];
+    }
+
+    // Relaciones
+    public function order()
+    {
+        return $this->belongsTo(Order::class);
+    }
+
+    public function courier()
+    {
+        return $this->belongsTo(User::class, 'courier_id');
+    }
+
+    public function lastTrack()
+    {
+        return $this->belongsTo(DeliveryTrack::class, 'last_track_id');
+    }
+
+    public function tracks()
+    {
+        return $this->hasMany(DeliveryTrack::class);
+    }
+}

--- a/app/Models/DeliveryTrack.php
+++ b/app/Models/DeliveryTrack.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class DeliveryTrack extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'delivery_id',
+        'latitude',
+        'longitude',
+        'recorded_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'recorded_at' => 'datetime',
+        ];
+    }
+
+    public function delivery()
+    {
+        return $this->belongsTo(Delivery::class);
+    }
+}

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Order extends Model
+{
+    use HasFactory;
+
+    /**
+     * Atributos asignables de forma masiva.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'user_id',
+        'business_id',
+        'total_items',
+        'total_amount',
+        'status',
+        'payment_method',
+        'order_type',
+        'delivery_address',
+        'notes',
+        'delivery_method',
+        'address',
+        'latitude',
+        'longitude',
+        'assigned_delivery_id',
+        'delivered_at',
+        'canceled_at',
+    ];
+
+    /**
+     * Conversión de atributos a tipos nativos.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'delivered_at' => 'datetime',
+            'canceled_at'  => 'datetime',
+        ];
+    }
+
+    // Relaciones
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function business()
+    {
+        return $this->belongsTo(User::class, 'business_id');
+    }
+
+    public function delivery()
+    {
+        return $this->belongsTo(Delivery::class, 'assigned_delivery_id');
+    }
+}

--- a/database/migrations/2025_06_17_013105_alter_orders_add_delivery_tracking_columns.php
+++ b/database/migrations/2025_06_17_013105_alter_orders_add_delivery_tracking_columns.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->string('delivery_method')->nullable()->after('order_type');
+            $table->string('address')->nullable()->after('delivery_method');
+            $table->decimal('latitude', 10, 6)->nullable()->after('address');
+            $table->decimal('longitude', 10, 6)->nullable()->after('latitude');
+            $table->foreignId('assigned_delivery_id')->nullable()->constrained('deliveries')->after('notes');
+            $table->timestamp('delivered_at')->nullable()->after('assigned_delivery_id');
+            $table->timestamp('canceled_at')->nullable()->after('delivered_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropForeign(['assigned_delivery_id']);
+            $table->dropColumn([
+                'delivery_method',
+                'address',
+                'latitude',
+                'longitude',
+                'assigned_delivery_id',
+                'delivered_at',
+                'canceled_at',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2025_06_17_013106_alter_deliveries_add_verification_columns.php
+++ b/database/migrations/2025_06_17_013106_alter_deliveries_add_verification_columns.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('deliveries', function (Blueprint $table) {
+            $table->timestamp('picked_up_at')->nullable()->after('status');
+            $table->string('pickup_code', 10)->nullable()->after('picked_up_at');
+            $table->timestamp('pickup_verified_at')->nullable()->after('pickup_code');
+            $table->string('delivery_code', 10)->nullable()->after('pickup_verified_at');
+            $table->timestamp('delivery_verified_at')->nullable()->after('delivery_code');
+            $table->foreignId('last_track_id')->nullable()->after('delivery_verified_at')
+                ->constrained('delivery_tracks')->nullOnDelete();
+            $table->timestamp('canceled_at')->nullable()->after('delivered_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('deliveries', function (Blueprint $table) {
+            $table->dropForeign(['last_track_id']);
+            $table->dropColumn([
+                'picked_up_at',
+                'pickup_code',
+                'pickup_verified_at',
+                'delivery_code',
+                'delivery_verified_at',
+                'last_track_id',
+                'canceled_at',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2025_06_17_013107_alter_delivery_tracks_add_timestamps.php
+++ b/database/migrations/2025_06_17_013107_alter_delivery_tracks_add_timestamps.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('delivery_tracks', function (Blueprint $table) {
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('delivery_tracks', function (Blueprint $table) {
+            $table->dropTimestamps();
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add delivery tracking fields to orders and deliveries
- capture track timestamps
- create `Order`, `Delivery` and `DeliveryTrack` models

## Testing
- `./vendor/bin/phpunit --no-coverage`

------
https://chatgpt.com/codex/tasks/task_e_6850d37d8be8832981a09b79ae192ea3