### PR TITLE
Create support chat and notification foundation

### DIFF
--- a/app/Events/SupportChatMessageSent.php
+++ b/app/Events/SupportChatMessageSent.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\SupportChatMessage;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Queue\SerializesModels;
+
+class SupportChatMessageSent implements ShouldBroadcastNow
+{
+    use InteractsWithSockets, SerializesModels;
+
+    public SupportChatMessage $message;
+
+    public function __construct(SupportChatMessage $message)
+    {
+        $this->message = $message;
+    }
+
+    public function broadcastOn(): array
+    {
+        return [new PrivateChannel('support-chat.' . $this->message->chat_id)];
+    }
+}

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Notification;
+use Illuminate\Http\Request;
+
+class NotificationController extends Controller
+{
+    /**
+     * Listar notificaciones del usuario autenticado.
+     */
+    public function index(Request $request)
+    {
+        $notifications = Notification::where('user_id', $request->user()->id)
+            ->latest()->get();
+
+        return response()->json(['notifications' => $notifications]);
+    }
+}

--- a/app/Http/Controllers/SupportChatController.php
+++ b/app/Http/Controllers/SupportChatController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Events\SupportChatMessageSent;
+use App\Models\SupportChat;
+use App\Models\SupportChatMessage;
+use Illuminate\Http\Request;
+
+class SupportChatController extends Controller
+{
+    /**
+     * Crear un chat de soporte asociado a un pedido o recarga.
+     */
+    public function store(Request $request)
+    {
+        $fields = $request->validate([
+            'order_id' => 'nullable|exists:orders,id',
+            'recharge_id' => 'nullable|exists:recharges,id',
+        ]);
+
+        $chat = SupportChat::create([
+            'user_id' => $request->user()->id,
+            'order_id' => $fields['order_id'] ?? null,
+            'recharge_id' => $fields['recharge_id'] ?? null,
+            'status' => 'open',
+        ]);
+
+        return response()->json(['chat' => $chat], 201);
+    }
+
+    /**
+     * Enviar mensaje dentro de un chat de soporte.
+     */
+    public function sendMessage(Request $request, SupportChat $chat)
+    {
+        $fields = $request->validate([
+            'message' => 'required|string',
+        ]);
+
+        $message = SupportChatMessage::create([
+            'chat_id' => $chat->id,
+            'sender_id' => $request->user()->id,
+            'message' => $fields['message'],
+        ]);
+
+        broadcast(new SupportChatMessageSent($message))->toOthers();
+
+        return response()->json(['message' => $message], 201);
+    }
+}

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Notification extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'order_id',
+        'recharge_id',
+        'type',
+        'data',
+        'read_at',
+    ];
+
+    protected $casts = [
+        'data' => 'array',
+        'read_at' => 'datetime',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function order()
+    {
+        return $this->belongsTo(Order::class);
+    }
+
+    public function recharge()
+    {
+        return $this->belongsTo(Recharge::class);
+    }
+}

--- a/app/Models/SupportChat.php
+++ b/app/Models/SupportChat.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SupportChat extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'agent_id',
+        'order_id',
+        'recharge_id',
+        'status',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function agent()
+    {
+        return $this->belongsTo(User::class, 'agent_id');
+    }
+
+    public function order()
+    {
+        return $this->belongsTo(Order::class);
+    }
+
+    public function recharge()
+    {
+        return $this->belongsTo(Recharge::class);
+    }
+
+    public function messages()
+    {
+        return $this->hasMany(SupportChatMessage::class, 'chat_id');
+    }
+}

--- a/app/Models/SupportChatMessage.php
+++ b/app/Models/SupportChatMessage.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SupportChatMessage extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'chat_id',
+        'sender_id',
+        'message',
+    ];
+
+    public function chat()
+    {
+        return $this->belongsTo(SupportChat::class, 'chat_id');
+    }
+
+    public function sender()
+    {
+        return $this->belongsTo(User::class, 'sender_id');
+    }
+}

--- a/database/migrations/2025_06_17_013012_create_support_chats_table.php
+++ b/database/migrations/2025_06_17_013012_create_support_chats_table.php
@@ -12,6 +12,8 @@ return new class extends Migration
             $table->id();
             $table->foreignId('user_id')->constrained('users');
             $table->foreignId('agent_id')->nullable()->constrained('users');
+            $table->foreignId('order_id')->nullable()->constrained('orders');
+            $table->foreignId('recharge_id')->nullable()->constrained('recharges');
             $table->enum('status', ['open', 'closed'])->default('open');
             $table->timestamps();
         });

--- a/database/migrations/2025_06_17_013013_create_support_chat_messages_table.php
+++ b/database/migrations/2025_06_17_013013_create_support_chat_messages_table.php
@@ -8,7 +8,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('support_messages', function (Blueprint $table) {
+        Schema::create('support_chat_messages', function (Blueprint $table) {
             $table->id();
             $table->foreignId('chat_id')->constrained('support_chats')->onDelete('cascade');
             $table->foreignId('sender_id')->constrained('users');
@@ -19,6 +19,6 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::dropIfExists('support_messages');
+        Schema::dropIfExists('support_chat_messages');
     }
 };

--- a/database/migrations/2025_06_17_013014_create_notifications_table.php
+++ b/database/migrations/2025_06_17_013014_create_notifications_table.php
@@ -11,6 +11,8 @@ return new class extends Migration
         Schema::create('notifications', function (Blueprint $table) {
             $table->id();
             $table->foreignId('user_id')->constrained('users');
+            $table->foreignId('order_id')->nullable()->constrained('orders');
+            $table->foreignId('recharge_id')->nullable()->constrained('recharges');
             $table->string('type', 50);
             $table->json('data');
             $table->timestamp('read_at')->nullable();

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,8 @@ use App\Http\Controllers\AuthController;
 use App\Http\Controllers\UserController; // 👈 asegurate de importar
 use App\Http\Controllers\RechargeController;
 use App\Http\Controllers\TransferController;
+use App\Http\Controllers\SupportChatController;
+use App\Http\Controllers\NotificationController;
 
 /*
 |--------------------------------------------------------------------------
@@ -28,6 +30,11 @@ Route::middleware('auth:sanctum')->group(function () {
     // Recargas y transferencias
     Route::post('/recharges', [RechargeController::class, 'store']);
     Route::post('/transfers', [TransferController::class, 'store']);
+
+    // Soporte y notificaciones
+    Route::post('/support/chats', [SupportChatController::class, 'store']);
+    Route::post('/support/chats/{chat}/messages', [SupportChatController::class, 'sendMessage']);
+    Route::get('/notifications', [NotificationController::class, 'index']);
 });
 
 // 🔒 Rutas específicas por rol


### PR DESCRIPTION
## Summary
- build migrations with order & recharge references for support and notifications tables
- add initial models, controllers and event for support chats
- define routes for support chat creation, sending messages and listing notifications
- enable basic broadcasting of support chat messages

## Testing
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6850d72a078c83299c3a82f0e288f4e1