### PR TITLE
Add catalog migrations and update products

### DIFF
--- a/database/migrations/2025_06_18_000000_create_categories_table.php
+++ b/database/migrations/2025_06_18_000000_create_categories_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 100);
+            $table->string('slug', 100)->unique();
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/database/migrations/2025_06_18_000100_create_subcategories_table.php
+++ b/database/migrations/2025_06_18_000100_create_subcategories_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('subcategories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('category_id')->constrained('categories');
+            $table->string('name', 100);
+            $table->string('slug', 100)->unique();
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('subcategories');
+    }
+};

--- a/database/migrations/2025_06_18_000200_create_category_tags_table.php
+++ b/database/migrations/2025_06_18_000200_create_category_tags_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('category_tags', function (Blueprint $table) {
+            $table->foreignId('category_id')->constrained('categories')->onDelete('cascade');
+            $table->foreignId('tag_id')->constrained('tags')->onDelete('cascade');
+            $table->primary(['category_id', 'tag_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('category_tags');
+    }
+};

--- a/database/migrations/2025_06_18_000300_rename_product_bundles_to_product_bundle_items.php
+++ b/database/migrations/2025_06_18_000300_rename_product_bundles_to_product_bundle_items.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::rename('product_bundles', 'product_bundle_items');
+    }
+
+    public function down(): void
+    {
+        Schema::rename('product_bundle_items', 'product_bundles');
+    }
+};

--- a/database/migrations/2025_06_18_000310_create_product_bundles_table.php
+++ b/database/migrations/2025_06_18_000310_create_product_bundles_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('product_bundles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('business_id')->constrained('businesses');
+            $table->string('name', 100);
+            $table->string('slug', 100)->unique();
+            $table->text('description')->nullable();
+            $table->decimal('price', 10, 2);
+            $table->integer('stock')->default(0);
+            $table->enum('status', ['active', 'inactive'])->default('active');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('product_bundles');
+    }
+};

--- a/database/migrations/2025_06_18_000400_create_product_sales_history_table.php
+++ b/database/migrations/2025_06_18_000400_create_product_sales_history_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('product_sales_history', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('product_id')->constrained('products');
+            $table->integer('quantity')->default(1);
+            $table->decimal('price', 10, 2);
+            $table->timestamp('sold_at');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('product_sales_history');
+    }
+};

--- a/database/migrations/2025_06_18_000500_create_favorites_table.php
+++ b/database/migrations/2025_06_18_000500_create_favorites_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('favorites', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users');
+            $table->foreignId('product_id')->constrained('products');
+            $table->timestamps();
+
+            $table->unique(['user_id', 'product_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('favorites');
+    }
+};

--- a/database/migrations/2025_06_18_000600_rename_product_tag_to_product_tags.php
+++ b/database/migrations/2025_06_18_000600_rename_product_tag_to_product_tags.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::rename('product_tag', 'product_tags');
+    }
+
+    public function down(): void
+    {
+        Schema::rename('product_tags', 'product_tag');
+    }
+};

--- a/database/migrations/2025_06_18_000700_alter_products_update_business_fk_and_add_fields.php
+++ b/database/migrations/2025_06_18_000700_alter_products_update_business_fk_and_add_fields.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropForeign(['business_id']);
+            $table->unsignedBigInteger('business_id')->change();
+            $table->foreign('business_id')->references('id')->on('businesses');
+            $table->string('image_main_url')->nullable()->after('barcode');
+            $table->decimal('rating', 3, 2)->default(0)->after('image_main_url');
+            $table->boolean('is_available')->default(true)->after('status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn(['image_main_url', 'rating', 'is_available']);
+            $table->dropForeign(['business_id']);
+            $table->unsignedBigInteger('business_id')->change();
+            $table->foreign('business_id')->references('id')->on('users');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add categories, subcategories and category tags tables
- rename pivot table for bundles and create bundles table
- create sales history and favorites tables
- rename product_tag table and update products foreign key
- add extra product metadata columns

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6850da6c0ddc8329bd527bfcdb5c40a5