### PR TITLE
Add Business controller and routes

### DIFF
--- a/app/Http/Controllers/BusinessController.php
+++ b/app/Http/Controllers/BusinessController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Business;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class BusinessController extends Controller
+{
+    /**
+     * Listar negocios disponibles.
+     */
+    public function index()
+    {
+        $businesses = Business::all();
+
+        return response()->json(['businesses' => $businesses]);
+    }
+
+    /**
+     * Mostrar un negocio en particular.
+     */
+    public function show(Business $business)
+    {
+        return response()->json(['business' => $business]);
+    }
+
+    /**
+     * Registrar un nuevo negocio para el usuario autenticado.
+     */
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name'          => 'required|string|max:100',
+            'description'   => 'nullable|string',
+            'logo_url'      => 'nullable|string|max:255',
+            'address1'      => 'nullable|string|max:255',
+            'address2'      => 'nullable|string|max:255',
+            'city_id'       => 'nullable|exists:cities,id',
+            'region_id'     => 'nullable|exists:regions,id',
+            'country_id'    => 'nullable|exists:countries,id',
+            'latitude'      => 'nullable|numeric|between:-90,90',
+            'longitude'     => 'nullable|numeric|between:-180,180',
+            'contact_email' => 'nullable|email',
+            'contact_phone' => 'nullable|string|max:20',
+            'website_url'   => 'nullable|url',
+        ]);
+
+        $data['user_id'] = $request->user()->id;
+        $data['slug'] = Str::slug($data['name']).'-'.Str::random(5);
+
+        $business = Business::create($data);
+
+        return response()->json(['business' => $business], 201);
+    }
+
+    /**
+     * Actualizar información de un negocio existente.
+     */
+    public function update(Request $request, Business $business)
+    {
+        $data = $request->validate([
+            'name'          => 'sometimes|string|max:100',
+            'description'   => 'nullable|string',
+            'logo_url'      => 'nullable|string|max:255',
+            'address1'      => 'nullable|string|max:255',
+            'address2'      => 'nullable|string|max:255',
+            'city_id'       => 'nullable|exists:cities,id',
+            'region_id'     => 'nullable|exists:regions,id',
+            'country_id'    => 'nullable|exists:countries,id',
+            'latitude'      => 'nullable|numeric|between:-90,90',
+            'longitude'     => 'nullable|numeric|between:-180,180',
+            'contact_email' => 'nullable|email',
+            'contact_phone' => 'nullable|string|max:20',
+            'website_url'   => 'nullable|url',
+        ]);
+
+        if (isset($data['name'])) {
+            $data['slug'] = Str::slug($data['name']).'-'.Str::random(5);
+        }
+
+        $business->update($data);
+
+        return response()->json(['business' => $business]);
+    }
+}

--- a/overview.md
+++ b/overview.md
@@ -41,6 +41,9 @@ Slodigt está diseñado como un **marketplace central** que permite a negocios l
 ### Gestión de Negocios
 Manejo de altas de negocios, aprobación y roles internos. Utiliza los modelos
 `Business`, `BusinessUserRole` y `BusinessReview`.
+Rutas disponibles:
+`GET /businesses`, `GET /businesses/{id}`,
+`POST /businesses`, `PUT /businesses/{id}` (requiere rol `business`).
 
 ### Catálogo de Productos
 Estructura de productos, variantes y categorías por negocio (tablas ya

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\RechargeController;
 use App\Http\Controllers\TransferController;
 use App\Http\Controllers\SupportChatController;
 use App\Http\Controllers\NotificationController;
+use App\Http\Controllers\BusinessController;
 
 /*
 |--------------------------------------------------------------------------
@@ -30,6 +31,14 @@ Route::middleware('auth:sanctum')->group(function () {
     // Recargas y transferencias
     Route::post('/recharges', [RechargeController::class, 'store']);
     Route::post('/transfers', [TransferController::class, 'store']);
+
+    // Gestión de negocios
+    Route::get('/businesses', [BusinessController::class, 'index']);
+    Route::get('/businesses/{business}', [BusinessController::class, 'show']);
+    Route::middleware('role:business')->group(function () {
+        Route::post('/businesses', [BusinessController::class, 'store']);
+        Route::put('/businesses/{business}', [BusinessController::class, 'update']);
+    });
 
     // Soporte y notificaciones
     Route::post('/support/chats', [SupportChatController::class, 'store']);


### PR DESCRIPTION
## Summary
- implement `BusinessController` with CRUD basics
- protect `/businesses` routes with sanctum and business role
- list new endpoints in overview docs

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6850e6bffc248329a432d268e3b34310