### PR TITLE
Add Business policy with authorization checks

### DIFF
--- a/app/Http/Controllers/BusinessController.php
+++ b/app/Http/Controllers/BusinessController.php
@@ -23,6 +23,8 @@ class BusinessController extends Controller
      */
     public function show(Business $business)
     {
+        $this->authorize('view', $business);
+
         return response()->json(['business' => $business]);
     }
 
@@ -31,6 +33,8 @@ class BusinessController extends Controller
      */
     public function store(Request $request)
     {
+        $this->authorize('create', Business::class);
+
         $data = $request->validate([
             'name'          => 'required|string|max:100',
             'description'   => 'nullable|string',
@@ -60,6 +64,8 @@ class BusinessController extends Controller
      */
     public function update(Request $request, Business $business)
     {
+        $this->authorize('update', $business);
+
         $data = $request->validate([
             'name'          => 'sometimes|string|max:100',
             'description'   => 'nullable|string',

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,7 +2,11 @@
 
 namespace App\Http\Controllers;
 
-abstract class Controller
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Routing\Controller as BaseController;
+
+abstract class Controller extends BaseController
 {
-    //
+    use AuthorizesRequests, ValidatesRequests;
 }

--- a/app/Policies/BusinessPolicy.php
+++ b/app/Policies/BusinessPolicy.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Business;
+use App\Models\User;
+
+class BusinessPolicy
+{
+    /**
+     * Determine whether the user can view the business.
+     */
+    public function view(?User $user, Business $business): bool
+    {
+        return true;
+    }
+    /**
+     * Determine whether the user can create a business.
+     */
+    public function create(User $user): bool
+    {
+        // Only users with the business role may create businesses
+        return $user->role === 'business';
+    }
+
+    /**
+     * Determine whether the user can update the business.
+     */
+    public function update(User $user, Business $business): bool
+    {
+        return $user->id === $business->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the business.
+     */
+    public function delete(User $user, Business $business): bool
+    {
+        return $user->id === $business->user_id;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Providers;
+
+use App\Models\Business;
+use App\Policies\BusinessPolicy;
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    /**
+     * The policy mappings for the application.
+     *
+     * @var array<class-string, class-string>
+     */
+    protected $policies = [
+        Business::class => BusinessPolicy::class,
+    ];
+
+    /**
+     * Register any authentication / authorization services.
+     */
+    public function boot(): void
+    {
+        //
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -2,4 +2,5 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    App\Providers\AuthServiceProvider::class,
 ];

--- a/tests/Feature/BusinessPolicyTest.php
+++ b/tests/Feature/BusinessPolicyTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Business;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BusinessPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_cannot_update_other_business(): void
+    {
+        $owner = User::factory()->create(['role' => 'business']);
+        $other = User::factory()->create(['role' => 'business']);
+        $business = Business::factory()->create(['user_id' => $owner->id]);
+
+        $token = $other->createToken('auth_token')->plainTextToken;
+
+        $this->withHeader('Authorization', 'Bearer '.$token)
+            ->putJson('/api/businesses/'.$business->id, [
+                'name' => 'New Name',
+            ])
+            ->assertStatus(403);
+    }
+
+    public function test_owner_can_update_their_business(): void
+    {
+        $owner = User::factory()->create(['role' => 'business']);
+        $business = Business::factory()->create(['user_id' => $owner->id]);
+
+        $token = $owner->createToken('auth_token')->plainTextToken;
+
+        $this->withHeader('Authorization', 'Bearer '.$token)
+            ->putJson('/api/businesses/'.$business->id, [
+                'name' => 'Updated',
+            ])
+            ->assertOk();
+    }
+}


### PR DESCRIPTION
## Summary
- ensure users only manage their own businesses via `BusinessPolicy`
- register new policy with `AuthServiceProvider`
- add `AuthorizesRequests` to base controller
- enforce policy checks in `BusinessController`
- register auth provider
- add feature tests for policy behaviour

## Testing
- `php artisan test --testsuite Feature`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6850ed88f13883298d2f1402a3b5f343