### PR TITLE
Add business API feature tests

### DIFF
--- a/app/Http/Controllers/BusinessController.php
+++ b/app/Http/Controllers/BusinessController.php
@@ -11,9 +11,19 @@ class BusinessController extends Controller
     /**
      * Listar negocios disponibles.
      */
-    public function index()
+    public function index(Request $request)
     {
-        $businesses = Business::all();
+        $query = Business::query();
+
+        if ($request->filled('search')) {
+            $query->where('name', 'like', '%' . $request->search . '%');
+        }
+
+        if ($request->filled('city_id')) {
+            $query->where('city_id', $request->city_id);
+        }
+
+        $businesses = $query->get();
 
         return response()->json(['businesses' => $businesses]);
     }

--- a/app/Http/Controllers/BusinessRoleController.php
+++ b/app/Http/Controllers/BusinessRoleController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Business;
+use App\Models\BusinessUserRole;
+use Illuminate\Http\Request;
+
+class BusinessRoleController extends Controller
+{
+    public function store(Request $request, Business $business)
+    {
+        $this->authorize('update', $business);
+
+        $data = $request->validate([
+            'user_id' => 'required|exists:users,id',
+            'role' => 'required|in:manager,staff',
+        ]);
+
+        $role = BusinessUserRole::updateOrCreate(
+            ['business_id' => $business->id, 'user_id' => $data['user_id']],
+            ['role' => $data['role']]
+        );
+
+        return response()->json(['role' => $role], 201);
+    }
+
+    public function update(Request $request, Business $business, BusinessUserRole $role)
+    {
+        $this->authorize('update', $business);
+
+        if ($role->business_id !== $business->id) {
+            abort(404);
+        }
+
+        $data = $request->validate([
+            'role' => 'required|in:manager,staff',
+        ]);
+
+        $role->update($data);
+
+        return response()->json(['role' => $role]);
+    }
+
+    public function destroy(Request $request, Business $business, BusinessUserRole $role)
+    {
+        $this->authorize('update', $business);
+
+        if ($role->business_id !== $business->id) {
+            abort(404);
+        }
+
+        $role->delete();
+
+        return response()->json([], 204);
+    }
+}

--- a/database/factories/BusinessUserRoleFactory.php
+++ b/database/factories/BusinessUserRoleFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\BusinessUserRole;
+use App\Models\Business;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class BusinessUserRoleFactory extends Factory
+{
+    protected $model = BusinessUserRole::class;
+
+    public function definition(): array
+    {
+        return [
+            'business_id' => Business::factory(),
+            'user_id' => User::factory(),
+            'role' => 'staff',
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -38,6 +38,10 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::middleware('role:business')->group(function () {
         Route::post('/businesses', [BusinessController::class, 'store']);
         Route::put('/businesses/{business}', [BusinessController::class, 'update']);
+
+        Route::post('/businesses/{business}/roles', [\App\Http\Controllers\BusinessRoleController::class, 'store']);
+        Route::put('/businesses/{business}/roles/{role}', [\App\Http\Controllers\BusinessRoleController::class, 'update']);
+        Route::delete('/businesses/{business}/roles/{role}', [\App\Http\Controllers\BusinessRoleController::class, 'destroy']);
     });
 
     // Soporte y notificaciones

--- a/tests/Feature/BusinessApiTest.php
+++ b/tests/Feature/BusinessApiTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Business;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BusinessApiTest extends TestCase
+{
+    use RefreshDatabase;
+    public function test_business_can_be_created_via_api(): void
+    {
+        $user = User::factory()->create(['role' => 'business']);
+        $token = $user->createToken('auth_token')->plainTextToken;
+
+        $data = Business::factory()->make()->toArray();
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/businesses', $data);
+
+        $response->assertCreated()
+            ->assertJsonStructure(['business' => ['id', 'name', 'slug']]);
+
+        $this->assertDatabaseHas('businesses', ['name' => $data['name']]);
+    }
+
+    public function test_business_can_be_updated_via_api(): void
+    {
+        $user = User::factory()->create(['role' => 'business']);
+        $business = Business::factory()->create(['user_id' => $user->id]);
+        $token = $user->createToken('auth_token')->plainTextToken;
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->putJson('/api/businesses/' . $business->id, ['name' => 'Updated Name']);
+
+        $response->assertOk()
+            ->assertJsonStructure(['business' => ['id', 'name']]);
+
+        $this->assertDatabaseHas('businesses', ['id' => $business->id, 'name' => 'Updated Name']);
+    }
+
+    public function test_owner_can_invite_and_manage_roles(): void
+    {
+        $owner = User::factory()->create(['role' => 'business']);
+        $business = Business::factory()->create(['user_id' => $owner->id]);
+        $user = User::factory()->create();
+        $token = $owner->createToken('auth_token')->plainTextToken;
+
+        $invite = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/businesses/' . $business->id . '/roles', [
+                'user_id' => $user->id,
+                'role' => 'staff',
+            ]);
+
+        $invite->assertCreated()
+            ->assertJsonStructure(['role' => ['id', 'business_id', 'user_id', 'role']]);
+
+        $roleId = $invite->json('role.id');
+
+        $update = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->putJson('/api/businesses/' . $business->id . '/roles/' . $roleId, [
+                'role' => 'manager',
+            ]);
+
+        $update->assertOk()
+            ->assertJson(['role' => ['id' => $roleId, 'role' => 'manager']]);
+
+        $delete = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->deleteJson('/api/businesses/' . $business->id . '/roles/' . $roleId);
+
+        $delete->assertStatus(204);
+
+        $this->assertDatabaseMissing('business_user_roles', ['id' => $roleId]);
+    }
+
+    public function test_list_public_businesses_with_filters(): void
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('auth_token')->plainTextToken;
+
+        Business::factory()->for(User::factory(), 'owner')->create(['name' => 'Pizza Place']);
+        Business::factory()->for(User::factory(), 'owner')->create(['name' => 'Burger Joint']);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->getJson('/api/businesses?search=Pizza');
+
+        $response->assertOk()
+            ->assertJsonStructure(['businesses'])
+            ->assertJsonCount(1, 'businesses');
+    }
+}


### PR DESCRIPTION
## Summary
- support filters in `BusinessController@index`
- add `BusinessRoleController` for user role management
- define `BusinessUserRoleFactory`
- test business creation, updates, role invitations, and listing with filters

## Testing
- `php vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6850eef64a188329bc6c5084074f199e